### PR TITLE
ampersand fix

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -149,7 +149,7 @@
         <img src='https://secure.meetupstatic.com/photos/member/4/b/c/0/member_156379392.jpeg'> 
     </figure>
     <div class="loop__content clearfix">
-        <strong>Michael Easter</strong> - An early co-organizer of the group, Michael has given several presentations, performed &#39;cat-herding&#39; logistics, and sponsored the rare MeetUp. An advocate of Open Data, he founded and sponsors the PEI Open Data Book Club as a side-project within the PEI Devs umbrella. Outside of tech hobbies, Michael enjoys running and dabbling with guitar &amp;amp; piano.
+        <strong>Michael Easter</strong> - An early co-organizer of the group, Michael has given several presentations, performed &#39;cat-herding&#39; logistics, and sponsored the rare MeetUp. An advocate of Open Data, he founded and sponsors the PEI Open Data Book Club as a side-project within the PEI Devs umbrella. Outside of tech hobbies, Michael enjoys running and dabbling with guitar and piano.
     </div>
 </article>
 


### PR DESCRIPTION
Removing unescaped '&'. I vaguely wondered what would happen when writing that.