### PR TITLE
Override tweet shortcode when served with builtin hugo server

### DIFF
--- a/layouts/shortcodes/tweet.html
+++ b/layouts/shortcodes/tweet.html
@@ -1,0 +1,6 @@
+{{ if not .Site.IsServer }}
+    {{ template "_internal/shortcodes/twitter.html" . }}
+{{ else }}
+    <!-- Render the placeholder for the shortcode -->
+    <pre>Twitter embed: {{ .Get 0 }}</pre>
+{{ end }}


### PR DESCRIPTION
When running via `hugo server`, it overrides the `tweet` shortcode. Otherwise, does the default full Tweet rendering.

This allows Evan's MacBook to run the website locally. Fixes #23 